### PR TITLE
don't (incorrectly) warn on `break` in fall-through `case` label

### DIFF
--- a/C/SyntaxTree.cpp
+++ b/C/SyntaxTree.cpp
@@ -204,7 +204,7 @@ void SyntaxTree::buildTree(SyntaxCategory syntaxCat)
 
         case SyntaxCategory::Statements: {
             StatementSyntax* stmt = nullptr;
-            parser.parseStatement(stmt);
+            parser.parseStatement(stmt, Parser::StatementContext::None);
             P->rootNode_ = stmt;
             break;
          }

--- a/C/parser/Parser.h
+++ b/C/parser/Parser.h
@@ -196,7 +196,8 @@ private:
     enum class StatementContext : uint8_t
     {
         None,
-        WithinSwitch
+        WithinSwitch,
+        WithinLoop,
     };
 
     template <class NodeT, class... Args> NodeT* makeNode(Args&&... args) const;
@@ -376,24 +377,23 @@ private:
     //------------//
     // Statements //
     //------------//
-    bool parseStatement(StatementSyntax*& stmt,
-                        StatementContext stmtCtx = StatementContext::None);
+    bool parseStatement(StatementSyntax*& stmt, StatementContext stmtCtx);
     bool parseCompoundStatement_AtFirst(
             StatementSyntax*& stmt,
-            StatementContext stmtCtx = StatementContext::None);
+            StatementContext stmtCtx);
     bool parseDeclarationStatement(
             StatementSyntax*& stmt,
             bool (Parser::*parseDecl)(DeclarationSyntax*&));
     bool parseExpressionStatement(StatementSyntax*& stmt);
-    bool parseLabeledStatement_AtFirst(StatementSyntax*& stmt);
-    bool parseIfStatement_AtFirst(StatementSyntax*& stmt);
+    bool parseLabeledStatement_AtFirst(StatementSyntax*& stmt, StatementContext stmtCtx);
+    bool parseIfStatement_AtFirst(StatementSyntax*& stmt, StatementContext stmtCtx);
     bool parseSwitchStatement_AtFirst(StatementSyntax*& stmt);
-    bool parseWhileStatement_AtFirst(StatementSyntax*& stmt);
-    bool parseDoStatement_AtFirst(StatementSyntax*& stmt);
-    bool parseForStatement_AtFirst(StatementSyntax*& stmt);
+    bool parseWhileStatement_AtFirst(StatementSyntax*& stmt, StatementContext stmtCtx);
+    bool parseDoStatement_AtFirst(StatementSyntax*& stmt, StatementContext stmtCtx);
+    bool parseForStatement_AtFirst(StatementSyntax*& stmt, StatementContext stmtCtx);
     bool parseGotoStatement_AtFirst(StatementSyntax*& stmt);
-    bool parseContinueStatement_AtFirst(StatementSyntax*& stmt);
-    bool parseBreakStatement_AtFirst(StatementSyntax*& stmt);
+    bool parseContinueStatement_AtFirst(StatementSyntax*& stmt, StatementContext stmtCtx);
+    bool parseBreakStatement_AtFirst(StatementSyntax*& stmt, StatementContext stmtCtx);
     bool parseReturnStatement_AtFirst(StatementSyntax*& stmt);
     bool parseExtGNU_AsmStatement(StatementSyntax*& stmt);
     void parseExtGNU_AsmQualifiers(SpecifierListSyntax*& specList);

--- a/C/parser/Parser_Declarations.cpp
+++ b/C/parser/Parser_Declarations.cpp
@@ -333,7 +333,7 @@ bool Parser::parseDeclarationOrFunctionDefinition_AtFollowOfSpecifiers(
                         decl = funcDef;
                         funcDef->specs_ = const_cast<SpecifierListSyntax*>(specList);
                         funcDef->decltor_ = decltor;
-                        parseCompoundStatement_AtFirst(funcDef->body_);
+                        parseCompoundStatement_AtFirst(funcDef->body_, StatementContext::None);
                         return true;
                     }
                 }

--- a/C/parser/Parser_Expressions.cpp
+++ b/C/parser/Parser_Expressions.cpp
@@ -223,7 +223,7 @@ bool Parser::parseExtGNU_StatementExpression_AtFirst(ExpressionSyntax *&expr)
     gnuExpr->openParenTkIdx_ = consume();
 
     StatementSyntax* statement = nullptr;
-    parseCompoundStatement_AtFirst(statement);
+    parseCompoundStatement_AtFirst(statement, StatementContext::None);
     if (statement->asCompoundStatement())
         gnuExpr->stmt_ = statement->asCompoundStatement();
     return matchOrSkipTo(CloseParenToken, &gnuExpr->closeParenTkIdx_);
@@ -499,7 +499,7 @@ bool Parser::parseExpressionWithPrecedencePostfix(ExpressionSyntax*& expr)
         return false;
 
     while (true) {
-        SyntaxKind exprK = Unknown;
+        SyntaxKind exprK = UnknownSyntax;
         switch (peek().kind()) {
             /* 6.5.2.1 */
             case OpenBracketToken: {
@@ -541,7 +541,7 @@ bool Parser::parseExpressionWithPrecedencePostfix(ExpressionSyntax*& expr)
                 [[fallthrough]];
 
             case ArrowToken: {
-                if (exprK == Unknown)
+                if (exprK == UnknownSyntax)
                     exprK = IndirectMemberAccessExpression;
                 if (!parsePostfixExpression_AtPostfix<MemberAccessExpressionSyntax>(
                             expr,
@@ -569,7 +569,7 @@ bool Parser::parseExpressionWithPrecedencePostfix(ExpressionSyntax*& expr)
                 [[fallthrough]];
 
             case MinusMinusToken: {
-                if (exprK == Unknown)
+                if (exprK == UnknownSyntax)
                     exprK = PostDecrementExpression;
                 if (!parsePostfixExpression_AtPostfix<PostfixUnaryExpressionSyntax>(
                             expr,

--- a/C/syntax/SyntaxKind.h
+++ b/C/syntax/SyntaxKind.h
@@ -463,10 +463,11 @@ enum SyntaxKind : std::uint16_t
     AmbiguousCallOrVariableDeclaration,
     AmbiguousMultiplicationOrPointerDeclaration,
 
+    ENDof_Node = AmbiguousMultiplicationOrPointerDeclaration,
+
 //=================================================================== Misc
 
-    Unknown,
-    ENDof_Node = Unknown
+    UnknownSyntax
 };
 
 enum class SyntaxKindCategory : char

--- a/C/syntax/SyntaxNode.cpp
+++ b/C/syntax/SyntaxNode.cpp
@@ -462,7 +462,7 @@ std::string PSY_C_API to_string(SyntaxKind kind)
 
 //=================================================================== Misc
 
-        case Unknown:
+        case UnknownSyntax:
             return "<UNKNOWN>";
         default:
             return tokenNames[kind];

--- a/C/tests/TestParser_2000_2999.cpp
+++ b/C/tests/TestParser_2000_2999.cpp
@@ -997,7 +997,7 @@ void TestParser::case2352()
 {
     parseStatement(R"(
                    switch ( x ) {
-                       case 1: y ;
+                       case 1 : y ;
                        case 2 : z ( ) ;
                    }
                    )");
@@ -1012,7 +1012,7 @@ void TestParser::case2354()
 {
     parseStatement(R"(
                    switch ( x ) {
-                       case 1: y ;
+                       case 1 : y ;
                        default : z ( ) ;
                    }
                    )");
@@ -1041,7 +1041,16 @@ void TestParser::case2357()
                                                Parser::DiagnosticsReporter::ID_of_UnexpectedDefaultLabelOutsideSwitch));
 }
 
-void TestParser::case2358() {}
+void TestParser::case2358()
+{
+    parseStatement(R"(
+                   switch ( x ) {
+                       case 1 :
+                       case 2 : break;
+                   }
+                   )");
+}
+
 void TestParser::case2359() {}
 void TestParser::case2360() {}
 void TestParser::case2361() {}


### PR DESCRIPTION
fixes #19 