### PR TITLE
Implementing support for preprocessing large files #9

### DIFF
--- a/tools/CompilerFacade.cpp
+++ b/tools/CompilerFacade.cpp
@@ -23,6 +23,9 @@
 #include "Process.h"
 
 #include <iostream>
+#include <filesystem>
+#include <fstream>
+#include <unistd.h> /* for getpid */
 
 using namespace psy;
 
@@ -38,15 +41,35 @@ CompilerFacade::CompilerFacade(const std::string& hostCC,
 
 std::pair<int, std::string> CompilerFacade::preprocess(const std::string& source)
 {
-    std::string in = "cat << 'EOF' | ";
-    in += hostCC_;
+    // get the current process id
+    auto curr_pid = getpid();
+
+    // Base filename
+    auto base_name("psyche_" + std::to_string(curr_pid));
+
+    // Temporary directory name
+    auto tmp_dir(std::filesystem::temp_directory_path());
+
+    // Temporary filename
+    auto tmp_name(tmp_dir / base_name);
+
+    // Write our source to our temporary file
+    std::ofstream tmp_stream(tmp_name);
+    tmp_stream << source;
+
+    std::string in = hostCC_;
     in += macroSetup();
     in += " ";
     in += "-std=" + std_ + " ";
-    in += "-E -x c -CC -";
-    in += "\n" + source + "\nEOF";
+    in += "-E -x c -CC ";
+    in += tmp_name;
 
-    return Process().execute(in);
+    auto ret = Process().execute(in);
+
+    // remove the temporary file
+    std::remove(tmp_name.c_str());
+
+    return ret;
 }
 
 std::string CompilerFacade::macroSetup() const


### PR DESCRIPTION
This PR implements support for generating a per-process temporary file for the purposes of preprocessing; this allows `cnip` to be run on large files as follows:

```
./cnip --cc-pp /tmp/moo/b.c
```

Currently, master will do this:

```
cnip: preprocessor invocation failed
```

if the file to be preprocessed is large -- this will typically happen if the file is larger than `getconf ARG_MAX` in bytes (well, minus a few for the arguments `cnip` passes in).

**Currently, this code *is not* portable to Windows as `getpid` is POSIX (but there is https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/getpid?view=msvc-160)**


Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>