### PR TITLE
Remove 'declspec's on Windows as they are currently inconsistent #42

### DIFF
--- a/C/API.h
+++ b/C/API.h
@@ -23,19 +23,7 @@
 
 // From https://gcc.gnu.org/wiki/Visibility
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef EXPORT_API
-    #ifdef __GNUC__
-      #define PSY_C_API __attribute__ ((dllexport))
-    #else
-      #define PSY_C_API __declspec(dllexport)
-    #endif
-  #else
-    #ifdef __GNUC__
-      #define PSY_C_API __attribute__ ((dllimport))
-    #else
-      #define PSY_C_API __declspec(dllimport)
-    #endif
-  #endif
+  #define PSY_C_API
   #define PSY_C_API_LOCAL
 #else
   #if __GNUC__ >= 4

--- a/C/plugin-api/PluginConfig.h
+++ b/C/plugin-api/PluginConfig.h
@@ -23,19 +23,7 @@
 
 // From https://gcc.gnu.org/wiki/Visibility
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef EXPORT_API
-    #ifdef __GNUC__
-      #define PLUGIN_API __attribute__ ((dllexport))
-    #else
-      #define PLUGIN_API __declspec(dllexport)
-    #endif
-  #else
-    #ifdef __GNUC__
-      #define PLUGIN_API __attribute__ ((dllimport))
-    #else
-      #define PLUGIN_API __declspec(dllimport)
-    #endif
-  #endif
+  #define PLUGIN_API
   #define PLUGIN_API_LOCAL
 #else
   #if __GNUC__ >= 4

--- a/common/API.h
+++ b/common/API.h
@@ -23,19 +23,7 @@
 
 // From https://gcc.gnu.org/wiki/Visibility
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef EXPORT_API
-    #ifdef __GNUC__
-      #define PSY_API __attribute__ ((dllexport))
-    #else
-      #define PSY_API __declspec(dllexport)
-    #endif
-  #else
-    #ifdef __GNUC__
-      #define PSY_API __attribute__ ((dllimport))
-    #else
-      #define PSY_API __declspec(dllimport)
-    #endif
-  #endif
+  #define PSY_API
   #define PSY_API_LOCAL
 #else
   #if __GNUC__ >= 4


### PR DESCRIPTION
This is a "hack" to fix the build issues as reported in #42. While I can't say these changes are "better", currently nothing sets `EXPORT_API`, which then means a lot of `psychec`'s code ends-up with symbols having "incorrect" `declspec`s (leading to link-time issues).

I'd hoped that doing `ninja install` would remove the need for manually copying the DLL in-place:

- https://github.com/ltcmelo/psychec/issues/42#issuecomment-926449612

but the "new" branch still expects to find `psychecsolver-exe` (from "original"), which means you can't do the install, so I can't really test that theory.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>