### PR TITLE
Creating per-library EXPORT symbols

### DIFF
--- a/C/API.h
+++ b/C/API.h
@@ -23,7 +23,7 @@
 
 // From https://gcc.gnu.org/wiki/Visibility
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef EXPORT_API
+  #ifdef EXPORT_C_API
     #ifdef __GNUC__
       #define PSY_C_API __attribute__ ((dllexport))
     #else

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -15,7 +15,19 @@ set(CFE_CXX_FLAGS "${CFE_CXX_FLAGS} -g")
 set(CFE_CXX_FLAGS "${CFE_CXX_FLAGS} -Wall \
                                     -Wsign-compare")
 
+# Must happen before adding EXPORT_C_API to CFE_CXX_FLAGS
+set(CFE_CXX_FLAGS "${CFE_CXX_FLAGS} -DEXPORT_C_API")
+set(PLUGIN_CXX_FLAGS "${CFE_CXX_FLAGS} -DEXPORT_PLUGIN_API")
+
 set(CMAKE_MACOSX_RPATH TRUE)
+
+set(PLUGIN_SOURCES
+    # Plugin API files
+    ${PROJECT_SOURCE_DIR}/plugin-api/PluginConfig.h
+    ${PROJECT_SOURCE_DIR}/plugin-api/DeclarationInterceptor.h
+    ${PROJECT_SOURCE_DIR}/plugin-api/SourceInspector.h
+    ${PROJECT_SOURCE_DIR}/plugin-api/VisitorObserver.h
+)
 
 set(CFE_SOURCES
     # Main
@@ -103,12 +115,6 @@ set(CFE_SOURCES
     ${PROJECT_SOURCE_DIR}/names/DeclarationName.h
     ${PROJECT_SOURCE_DIR}/names/DeclarationNames.cpp
     ${PROJECT_SOURCE_DIR}/names/DeclarationNames.h
- 
-    # Plugin API files
-    ${PROJECT_SOURCE_DIR}/plugin-api/PluginConfig.h
-    ${PROJECT_SOURCE_DIR}/plugin-api/DeclarationInterceptor.h
-    ${PROJECT_SOURCE_DIR}/plugin-api/SourceInspector.h
-    ${PROJECT_SOURCE_DIR}/plugin-api/VisitorObserver.h
 
     # Tests
     ${PROJECT_SOURCE_DIR}/tests/TestBinder.h
@@ -125,6 +131,13 @@ set(CFE_SOURCES
     ${PROJECT_SOURCE_DIR}/tests/TestTypeChecker.cpp
 )
 
+foreach(file ${PLUGIN_SOURCES})
+    set_source_files_properties(
+        ${file} PROPERTIES
+        COMPILE_FLAGS "${PLUGIN_CXX_FLAGS}"
+    )
+endforeach()
+
 foreach(file ${CFE_SOURCES})
     set_source_files_properties(
         ${file} PROPERTIES
@@ -138,7 +151,7 @@ include_directories(
 )
 
 set(LIBRARY psychecfe)
-add_library(${LIBRARY} SHARED ${CFE_SOURCES})
+add_library(${LIBRARY} SHARED ${CFE_SOURCES} ${PLUGIN_SOURCES})
 
 target_link_libraries(${LIBRARY} psychecommon)
 

--- a/C/CMakeLists.txt
+++ b/C/CMakeLists.txt
@@ -15,7 +15,6 @@ set(CFE_CXX_FLAGS "${CFE_CXX_FLAGS} -g")
 set(CFE_CXX_FLAGS "${CFE_CXX_FLAGS} -Wall \
                                     -Wsign-compare")
 
-# Must happen before adding EXPORT_C_API to CFE_CXX_FLAGS
 set(CFE_CXX_FLAGS "${CFE_CXX_FLAGS} -DEXPORT_C_API")
 set(PLUGIN_CXX_FLAGS "${CFE_CXX_FLAGS} -DEXPORT_PLUGIN_API")
 

--- a/C/plugin-api/PluginConfig.h
+++ b/C/plugin-api/PluginConfig.h
@@ -23,7 +23,7 @@
 
 // From https://gcc.gnu.org/wiki/Visibility
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef EXPORT_API
+  #ifdef EXPORT_PLUGIN_API
     #ifdef __GNUC__
       #define PLUGIN_API __attribute__ ((dllexport))
     #else

--- a/C/stdlib-support/CMakeLists.txt
+++ b/C/stdlib-support/CMakeLists.txt
@@ -12,6 +12,8 @@ set(STD_CXX_FLAGS "${STD_CXX_FLAGS} -g")
 set(STD_CXX_FLAGS "${STD_CXX_FLAGS} -Wall \
                                     -Wsign-compare")
 
+set(STD_CXX_FLAGS "${STD_CXX_FLAGS} -DEXPORT_C_API -DEXPORT_PLUGIN_API")
+
 set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_INSTALL_RPATH "\$ORIGIN;@executable_path;@loader_path")
 

--- a/common/API.h
+++ b/common/API.h
@@ -23,7 +23,7 @@
 
 // From https://gcc.gnu.org/wiki/Visibility
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef EXPORT_API
+  #ifdef EXPORT_PSY_API
     #ifdef __GNUC__
       #define PSY_API __attribute__ ((dllexport))
     #else

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -11,6 +11,8 @@ set(COMMON_CXX_FLAGS)
 set(COMMON_CXX_FLAGS "${CFE_CXX_FLAGS} -g")
 set(COMMON_CXX_FLAGS "${CFE_CXX_FLAGS} -Wall \
                                        -Wsign-compare")
+set(COMMON_CXX_FLAGS "${CFE_CXX_FLAGS} -DEXPORT_PSY_API")
+
 
 set(CMAKE_MACOSX_RPATH TRUE)
 

--- a/common/diagnostics/Diagnostic.h
+++ b/common/diagnostics/Diagnostic.h
@@ -80,7 +80,7 @@ private:
     friend class C::TestFrontend;
 };
 
-std::ostream& operator<<(std::ostream& os, const Diagnostic& diagnostic);
+PSY_API std::ostream& operator<<(std::ostream& os, const Diagnostic& diagnostic);
 
 } // psy
 

--- a/common/location/LinePosition.h
+++ b/common/location/LinePosition.h
@@ -58,7 +58,7 @@ bool operator==(const LinePosition& a, const LinePosition& b);
 
 bool operator<(const LinePosition& a, const LinePosition& b);
 
-std::ostream& operator<<(std::ostream& os, const LinePosition& pos);
+PSY_API std::ostream& operator<<(std::ostream& os, const LinePosition& pos);
 
 } // psy
 


### PR DESCRIPTION
Makes the changes as discussed here:

- https://github.com/ltcmelo/psychec/pull/43#issuecomment-926553856

I should note that this _still_ doesn't work though (it does create `cnip.exe` though!) due to link failures in `test-suite.exe`:

```
<lots>
D:/DEV/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/test-suite.dir/tests/TestRunner.cpp.o:TestRunner.cpp:(.rdata$.refptr._ZN3psy1C10TestParser8case0002Ev[.refptr._ZN3psy1C10TestParser8case0002Ev]+0x0): undefined reference to `psy::C::TestParser::case0002()'
D:/DEV/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/test-suite.dir/tests/TestRunner.cpp.o:TestRunner.cpp:(.rdata$.refptr._ZN3psy1C10TestParser8case0001Ev[.refptr._ZN3psy1C10TestParser8case0001Ev]+0x0): undefined reference to `psy::C::TestParser::case0001()'
D:/DEV/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/10.3.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles/test-suite.dir/tests/TestRunner.cpp.o:TestRunner.cpp:(.rdata$.refptr._ZTVN3psy1C10TestParserE[.refptr._ZTVN3psy1C10TestParserE]+0x0): undefined reference to `vtable for psy::C::TestParser'
collect2.exe: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```


Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>