### PR TITLE
Disable 'test-suite' on Win32/MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,11 @@ set(GENERATOR cnip)
 add_executable(${GENERATOR} ${CNIPPET_SOURCES})
 target_link_libraries(${GENERATOR} psychecfe psychecommon dl)
 
-set(PSYCHE_TESTS test-suite)
-add_executable(${PSYCHE_TESTS} ${PSYCHE_TESTS_SOURCES})
-target_link_libraries(${PSYCHE_TESTS} psychecfe psychecommon dl)
+if (NOT WIN32 AND NOT MINGW)
+    set(PSYCHE_TESTS test-suite)
+    add_executable(${PSYCHE_TESTS} ${PSYCHE_TESTS_SOURCES})
+    target_link_libraries(${PSYCHE_TESTS} psychecfe psychecommon dl)
+endif()
 
 # Install setup
 install(TARGETS ${GENERATOR}


### PR DESCRIPTION
As discussed in #44 -- currently `psychec`'s tests live in `psychecfe.{so,dll}` and are not correctly exposed (on Windows) in a way that allows `test-suite.exe` to link against them.

This PR disables building the tests such that at least `cnip.exe` can be built on Win32/MinGW without link-time errors (in other parts of the build).

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>