### PR TITLE
Small fix to designator list parsing

### DIFF
--- a/C/parser/Parser_Declarations.cpp
+++ b/C/parser/Parser_Declarations.cpp
@@ -2248,6 +2248,7 @@ bool Parser::parseDesignatorList_AtFirst(DesignatorListSyntax*& desigList,
             return false;
 
         *desigs_cur = makeNode<DesignatorListSyntax>(desig);
+        desigs_cur = &(*desigs_cur)->next;
 
         switch (peek().kind()) {
             case DotToken:

--- a/C/tests/ParserTest_0000_0999.cpp
+++ b/C/tests/ParserTest_0000_0999.cpp
@@ -5143,12 +5143,35 @@ void ParserTest::case0862()
 
 void ParserTest::case0863()
 {
-
+    parseExpression("( struct x ) { . y [ 0 ] = 1 }",
+                    Expectation().AST( { CompoundLiteralExpression,
+                                         TypeName,
+                                         StructTypeSpecifier,
+                                         AbstractDeclarator,
+                                         BraceEnclosedInitializer,
+                                         DesignatedInitializer,
+                                         FieldDesignator,
+                                         ArrayDesignator,
+                                         IntegerConstantExpression,
+                                         ExpressionInitializer,
+                                         IntegerConstantExpression }));
 }
 
 void ParserTest::case0864()
 {
-
+    parseExpression("( struct x ) { . y [ 0 ] . z = 1 }",
+                    Expectation().AST( { CompoundLiteralExpression,
+                                         TypeName,
+                                         StructTypeSpecifier,
+                                         AbstractDeclarator,
+                                         BraceEnclosedInitializer,
+                                         DesignatedInitializer,
+                                         FieldDesignator,
+                                         ArrayDesignator,
+                                         IntegerConstantExpression,
+                                         FieldDesignator,
+                                         ExpressionInitializer,
+                                         IntegerConstantExpression }));
 }
 
 void ParserTest::case0865()


### PR DESCRIPTION
I'd expect the following test cases (added by me) on designated initializers to pass:

```c++
void ParserTest::case0863()
{
    parseExpression("( struct x ) { . y [ 0 ] = 1 }",
                    Expectation().AST( { CompoundLiteralExpression,
                                         TypeName,
                                         StructTypeSpecifier,
                                         AbstractDeclarator,
                                         BraceEnclosedInitializer,
                                         DesignatedInitializer,
                                         FieldDesignator,
                                         ArrayDesignator,
                                         IntegerConstantExpression,
                                         ExpressionInitializer,
                                         IntegerConstantExpression }));
}

void ParserTest::case0864()
{
    parseExpression("( struct x ) { . y [ 0 ] . z = 1 }",
                    Expectation().AST( { CompoundLiteralExpression,
                                         TypeName,
                                         StructTypeSpecifier,
                                         AbstractDeclarator,
                                         BraceEnclosedInitializer,
                                         DesignatedInitializer,
                                         FieldDesignator,
                                         ArrayDesignator,
                                         IntegerConstantExpression,
                                         FieldDesignator,
                                         ExpressionInitializer,
                                         IntegerConstantExpression }));
}
```

But they fail:

```
        -------------------------------------------------
	PARSER-case0863... 
!	FAIL
		Expected: (structx){.y[0]=1}
		Actual  : (structx){[0]=1}
		/home/luan/Documentos/psychec/C/tests/Test.cpp:194

	-------------------------------------------------
	PARSER-case0864... 
!	FAIL
		Expected: (structx){.y[0].z=1}
		Actual  : (structx){.z=1}
		/home/luan/Documentos/psychec/C/tests/Test.cpp:194

```

On

```
Author: Leandro T. C. Melo <ltcmelo@gmail.com>
Date:   Sat Feb 26 10:35:43 2022 -0300

    addSyntaxTrees -> addSyntaxTree
```

With the proposed change:

```
        -------------------------------------------------
	PARSER-case0863... OK
	-------------------------------------------------
	PARSER-case0864... OK
	-------------------------------------------------
...
PARSER Succeeded: 3999
PARSER Failed   : 0
BINDER Succeeded: 800
BINDER Failed   : 0
Succeeded: 4799
Failed   : 0
```