### PR TITLE
Implement the parse of parameters in K&R style functions

### DIFF
--- a/C/Fwds.h
+++ b/C/Fwds.h
@@ -90,6 +90,7 @@ class ExtGNU_AttributeSpecifierSyntax;
 class ExtGNU_AttributeSyntax;
 class ExtGNU_AsmLabelSyntax;
 class ExtPSY_QuantifiedTypeSpecifierSyntax;
+class ExtKR_ParameterDeclarationSyntax;
 
 /* Declarators */
 class DeclaratorSyntax;
@@ -198,6 +199,7 @@ typedef SyntaxNodeSeparatedList<ExpressionSyntax*> ExpressionListSyntax;
 typedef SyntaxNodeSeparatedList<GenericAssociationSyntax*> GenericAssociationListSyntax;
 typedef SyntaxNodePlainList<StatementSyntax*> StatementListSyntax;
 typedef SyntaxNodeSeparatedList<ExtGNU_AsmOperandSyntax*> ExtGNU_AsmOperandListSyntax;
+typedef SyntaxNodePlainList<ExtKR_ParameterDeclarationSyntax*> ExtKR_ParameterDeclarationListSyntax;
 
 //=================================================================== Semantic
 

--- a/C/parser/Parser.h
+++ b/C/parser/Parser.h
@@ -240,6 +240,10 @@ private:
     bool parseDeclarationOrFunctionDefinition_AtFollowOfSpecifiers(
             DeclarationSyntax*& decl,
             const SpecifierListSyntax* specList);
+    bool parseFunctionDefinition(
+            DeclarationSyntax*& decl,
+            const SpecifierListSyntax* specList,
+            DeclaratorSyntax*& decltor);
     bool parseStructDeclaration(DeclarationSyntax*& decl);
     bool parseStructDeclaration_AtFollowOfSpecifierQualifierList(
             DeclarationSyntax*& decl,
@@ -249,6 +253,8 @@ private:
     bool parseParameterDeclarationList(ParameterDeclarationListSyntax*& paramList);
     bool parseParameterDeclaration(ParameterDeclarationSyntax*& paramDecl);
     bool parseExtPSY_TemplateDeclaration_AtFirst(DeclarationSyntax*& decl);
+    bool parseExtKR_ParameterDeclarationList(ExtKR_ParameterDeclarationListSyntax*& paramList);
+    bool parseExtKR_ParameterDeclaration(ExtKR_ParameterDeclarationSyntax*& paramDecl);
 
     bool ignoreDeclarator();
     bool ignoreDeclarationOrDefinition();

--- a/C/syntax/SyntaxDumper.h
+++ b/C/syntax/SyntaxDumper.h
@@ -170,6 +170,8 @@ protected:
         for (auto iter = node->specifiers(); iter; iter = iter->next)
             nonterminal(iter->value);
         nonterminal(node->declarator());
+        for (auto iter = node->extKR_params(); iter; iter = iter->next)
+            nonterminal(iter->value);
         nonterminal(node->body());
         return Action::Skip;
     }
@@ -181,6 +183,18 @@ protected:
         terminal(node->openParenthesisToken(), node);
         nonterminal(node->stringLiteral());
         terminal(node->closeParenthesisToken(), node);
+        return Action::Skip;
+    }
+
+    virtual Action visitExtKR_ParameterDeclaration(const ExtKR_ParameterDeclarationSyntax* node) override
+    {
+        for (auto iter = node->specifiers(); iter; iter = iter->next)
+            nonterminal(iter->value);
+        for (auto iter = node->declarators(); iter; iter = iter->next) {
+            nonterminal(iter->value);
+            terminal(iter->delimiterToken(), node);
+        }
+        terminal(node->semicolonToken(), node);
         return Action::Skip;
     }
 

--- a/C/syntax/SyntaxKind.h
+++ b/C/syntax/SyntaxKind.h
@@ -317,6 +317,7 @@ enum SyntaxKind : std::uint16_t
     FunctionDefinition,
     ExtGNU_AsmStatementDeclaration,
     ExtPSY_TemplateDeclaration,
+    ExtKR_ParameterDeclaration,
 
     /* Specifiers */
     TypedefStorageClass,
@@ -356,6 +357,7 @@ enum SyntaxKind : std::uint16_t
     SubscriptSuffix,
     ParameterSuffix,
     BitfieldDeclaratorSuffix,
+    ExtKR_IdentifierDeclarator,
 
     /* Initializers */
     ExpressionInitializer,

--- a/C/syntax/SyntaxNode.cpp
+++ b/C/syntax/SyntaxNode.cpp
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include "SyntaxKind.h"
 #include "SyntaxNodes.h"
 #include "SyntaxVisitor.h"
 
@@ -170,6 +171,8 @@ std::string PSY_C_API to_string(SyntaxKind kind)
             return "ExtGNU_AsmStatementDeclaration";
         case ExtPSY_TemplateDeclaration:
             return "ExtPSY_TemplateDeclaration";
+        case ExtKR_ParameterDeclaration:
+            return "ExtKR_ParameterDeclaration";
 
         /* Specifiers */
         case TypedefStorageClass:

--- a/C/syntax/SyntaxNode.h
+++ b/C/syntax/SyntaxNode.h
@@ -148,6 +148,8 @@ public:
     virtual const ExtPSY_TemplateDeclarationSyntax* asExtPSY_TemplateDeclaration() const { return nullptr; }
     virtual ExtGNU_AsmStatementDeclarationSyntax* asExtGNU_AsmStatementDeclaration() { return nullptr; }
     virtual const ExtGNU_AsmStatementDeclarationSyntax* asExtGNU_AsmStatementDeclaration() const { return nullptr; }
+    virtual ExtKR_ParameterDeclarationSyntax* asExtKR_ParameterDeclaration() { return nullptr; }
+    virtual const ExtKR_ParameterDeclarationSyntax* asExtKR_ParameterDeclaration() const { return nullptr; }
 
     /* Specifiers */
     virtual SpecifierSyntax* asSpecifier() { return nullptr; }

--- a/C/syntax/SyntaxNodes_Declarations.h
+++ b/C/syntax/SyntaxNodes_Declarations.h
@@ -957,13 +957,16 @@ class PSY_C_API FunctionDefinitionSyntax final : public DeclarationSyntax
 public:
     const SpecifierListSyntax* specifiers() const { return specs_; }
     const DeclaratorSyntax* declarator() const { return decltor_; }
+    const ExtKR_ParameterDeclarationListSyntax *extKR_params()
+        const { return extKR_params_; }
     const StatementSyntax* body() const { return body_; }
 
 private:
     SpecifierListSyntax* specs_ = nullptr;
     DeclaratorSyntax* decltor_ = nullptr;
+    ExtKR_ParameterDeclarationListSyntax *extKR_params_ = nullptr;
     StatementSyntax* body_ = nullptr;
-    AST_CHILD_LST3(specs_, decltor_, body_);
+    AST_CHILD_LST4(specs_, decltor_, extKR_params_, body_);
 
     mutable FunctionSymbol* sym_;
 };
@@ -1016,6 +1019,37 @@ private:
     LexedTokens::IndexType templateTkIdx_ = LexedTokens::invalidIndex();
     DeclarationSyntax* decl_ = nullptr;
     AST_CHILD_LST2(templateTkIdx_, decl_)
+};
+
+/**
+ * \brief The ExtKR_ParameterDeclarationSyntax class.
+ *
+ * Parameter declaration in
+ * <a href="https://jameshfisher.com/2016/11/27/c-k-and-r/">K&R style</a>.
+ *
+ * \code{.c}
+ * int foo(x, y)
+ *     int x;
+ *     float y;
+ * {
+ *     return x + y;
+ * }
+ * \endcode
+ */
+class PSY_C_API ExtKR_ParameterDeclarationSyntax final : public DeclaratorDeclarationSyntax
+{
+    AST_NODE_1K(ExtKR_ParameterDeclaration, DeclaratorDeclaration)
+
+public:
+    const SpecifierListSyntax* specifiers() const { return specs_; }
+    const DeclaratorListSyntax* declarators() const { return decltors_; }
+    SyntaxToken semicolonToken() const { return tokenAtIndex(semicolonTkIdx_); }
+
+private:
+    SpecifierListSyntax* specs_ = nullptr;
+    DeclaratorListSyntax* decltors_ = nullptr;
+    LexedTokens::IndexType semicolonTkIdx_ = LexedTokens::invalidIndex();
+    AST_CHILD_LST3(specs_, decltors_, semicolonTkIdx_)
 };
 
 /* Initializers */

--- a/C/syntax/SyntaxVisitor.h
+++ b/C/syntax/SyntaxVisitor.h
@@ -84,6 +84,7 @@ public:
     virtual Action visitFunctionDefinition(const FunctionDefinitionSyntax*) { return Action::Visit; }
     virtual Action visitExtPSY_TemplateDeclaration(const ExtPSY_TemplateDeclarationSyntax*) { return Action::Visit; }
     virtual Action visitExtGNU_AsmStatementDeclaration(const ExtGNU_AsmStatementDeclarationSyntax*) { return Action::Visit; }
+    virtual Action visitExtKR_ParameterDeclaration(const ExtKR_ParameterDeclarationSyntax*) { return Action::Visit; }
 
     /* Specifiers */
     virtual Action visitStorageClass(const StorageClassSyntax*) { return Action::Visit; }

--- a/C/tests/ParserTest_0000_0999.cpp
+++ b/C/tests/ParserTest_0000_0999.cpp
@@ -2015,102 +2015,464 @@ void ParserTest::case0279()
 
 void ParserTest::case0280()
 {
-
+    parse("int x ( y ) { return y ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              IdentifierName }));
 }
 
 void ParserTest::case0281()
 {
-
+    parse("int x ( y ) int y ; { return y ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              IdentifierName }));
 }
 
 void ParserTest::case0282()
 {
-
+    parse("int x ( y , z ) int y ; { return y + z ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              AddExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0283()
 {
-
+    parse("int x ( y , z ) int y ; int z ; { return y + z ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              AddExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0284()
 {
-
+    parse("int x ( y , z ) int y , z ; { return y + z ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              AddExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0285()
 {
-
+    parse("int x ( y , z ) int y ; int z ( int ) ; { return y + z ( y ) ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              AbstractDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              AddExpression,
+                              IdentifierName,
+                              CallExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0286()
 {
-
+    parse("int x ( y ) struct t y ; { return y . z ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              StructTypeSpecifier,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              DirectMemberAccessExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0287()
 {
-
+    parse("int x ( y ) t y ; { return y . z ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              TypedefName,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              DirectMemberAccessExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0288()
 {
-
+    parse("int x ( y ) union t y ; { return y . z ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              UnionTypeSpecifier,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              DirectMemberAccessExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0289()
 {
-
+    parse("int x ( y ) int * y ; { return * y; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              PointerDeclarator,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              PointerIndirectionExpression,
+                              IdentifierName }));
 }
 
 void ParserTest::case0290()
 {
+    parse("int x ( y , z ) int * y , z ; { return * y + z ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              PointerDeclarator,
+                              IdentifierDeclarator,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              AddExpression,
+                              PointerIndirectionExpression,
+                              IdentifierName,
+                              IdentifierName }));
 
 }
 
 void ParserTest::case0291()
 {
+    parse("_Complex double x ( y ) _Complex double * y ; { return * y ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              BuiltinTypeSpecifier,
+                              PointerDeclarator,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              PointerIndirectionExpression,
+                              IdentifierName }));
 
 }
 
 void ParserTest::case0292()
 {
-
+    parse("float x ( y , z ) int y ( float [ 2 ] ) ; float * z  ; { return y ( z ) ; }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              ArrayDeclarator,
+                              SubscriptSuffix,
+                              IntegerConstantExpression,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              PointerDeclarator,
+                              IdentifierDeclarator,
+                              CompoundStatement,
+                              ReturnStatement,
+                              CallExpression,
+                              IdentifierName,
+                              IdentifierName }));
 }
 
 void ParserTest::case0293()
 {
-
+    parse("int x ( y , z ) int y , int z { return y + z ; }",
+          Expectation().diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ));
 }
 
 void ParserTest::case0294()
 {
-
+    parse("int x ( y ) y { return y ; }",
+          Expectation().diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ));
 }
 
 void ParserTest::case0295()
 {
-
+    parse("int x ( y ) int { return y ; }",
+          Expectation().diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ));
 }
 
 void ParserTest::case0296()
 {
-
+    parse("int x ( y ) int y { return y ; }",
+          Expectation().diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ));
 }
 
 void ParserTest::case0297()
 {
-
+    parse("int x ( t y ) int y ; { return y ; }",
+          Expectation().diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ));
 }
 
 void ParserTest::case0298()
 {
-
+    parse("int x ( int y ) int y ; { return y ; }",
+          Expectation().diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ));
 }
 
 void ParserTest::case0299()
 {
-
+    parse("int x ( int y , ... ) int z ; { return y ; }",
+          Expectation().diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Warn,
+              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
+          ).diagnostic(
+              Expectation::ErrorOrWarn::Error,
+              Parser::DiagnosticsReporter::
+              ID_of_ExpectedFIRSTofDirectDeclarator
+          ));
 }
 
 void ParserTest::case0300()


### PR DESCRIPTION
Issue #71 

It seems to be working, except perhaps for the backtrack and error messages. For instance, TestParser::case0296:

```C
int x ( y ) int y { return y ; }
```

The output for clang (version 13.0.1) is:

```
error: expected ';' at end of declaration
int x ( y ) int y  { return y ; }
                  ^
```

whereas in psychec I get:

```
<buffer>:0:12 error: expected `,' or `;' or `=' after declarator, got `int'
int x ( y ) int y { return y ; }
		            ^
		
<buffer>:0:31 warning: missing type specifier, assume `int'
int x ( y ) int y { return y ; }
		                               ^
		
<buffer>:0:31 error: expected <identifier> or `(' starting direct-declarator, got `}'
int x ( y ) int y { return y ; }
```

I was expecting the first error, but not the last one (the first comes from `diagReporter_.ExpectedFOLLOWofDeclarator()` at `Parser::parseDeclarationOrFunctionDefinition_AtFollowOfSpecifiers`, label default). 

Is that the expected behavior or did I miss something?
