### PR TITLE
complement PR #84 : parsing of K&R parameters

### DIFF
--- a/C/parser/Parser.h
+++ b/C/parser/Parser.h
@@ -240,10 +240,11 @@ private:
     bool parseDeclarationOrFunctionDefinition_AtFollowOfSpecifiers(
             DeclarationSyntax*& decl,
             const SpecifierListSyntax* specList);
-    bool parseFunctionDefinition(
+    bool parseFunctionDefinition_AtOpenBrace(
             DeclarationSyntax*& decl,
             const SpecifierListSyntax* specList,
-            DeclaratorSyntax*& decltor);
+            DeclaratorSyntax*& decltor,
+            ExtKR_ParameterDeclarationListSyntax* paramKRList);
     bool parseStructDeclaration(DeclarationSyntax*& decl);
     bool parseStructDeclaration_AtFollowOfSpecifierQualifierList(
             DeclarationSyntax*& decl,

--- a/C/parser/Parser.h
+++ b/C/parser/Parser.h
@@ -265,10 +265,10 @@ private:
     /* Specifiers */
     bool parseDeclarationSpecifiers(DeclarationSyntax*& decl,
                                     SpecifierListSyntax*& specList,
-                                    bool takeIdentifierAsDecltor = true);
+                                    bool allowIdentAsDecltor = true);
     bool parseSpecifierQualifierList(DeclarationSyntax*& decl,
                                      SpecifierListSyntax*& specList,
-                                     bool takeIdentifierAsDecltor = true);
+                                     bool allowIdentAsDecltor = true);
     template <class SpecT> void parseTrivialSpecifier_AtFirst(
             SpecifierSyntax*& spec,
             SyntaxKind specK);

--- a/C/parser/Parser.h
+++ b/C/parser/Parser.h
@@ -263,7 +263,7 @@ private:
     bool parseExtGNU_AsmStatementDeclaration_AtFirst(DeclarationSyntax*& decl);
     bool parseDeclaration(
             DeclarationSyntax*& decl,
-            bool (Parser::*parseSpecifiers)(DeclarationSyntax*&, SpecifierListSyntax*&, bool),
+            bool (Parser::*parseSpecifiers)(DeclarationSyntax*&, SpecifierListSyntax*&),
             bool (Parser::*parse_AtFollowOfSpecifiers)(DeclarationSyntax*&, const SpecifierListSyntax*),
             DeclarationScope declScope);
     bool parseDeclarationOrFunctionDefinition(DeclarationSyntax*& decl);
@@ -293,12 +293,8 @@ private:
     bool ignoreStatement();
 
     /* Specifiers */
-    bool parseDeclarationSpecifiers(DeclarationSyntax*& decl,
-                                    SpecifierListSyntax*& specList,
-                                    bool allowIdentAsDecltor = true);
-    bool parseSpecifierQualifierList(DeclarationSyntax*& decl,
-                                     SpecifierListSyntax*& specList,
-                                     bool allowIdentAsDecltor = true);
+    bool parseDeclarationSpecifiers(DeclarationSyntax*& decl, SpecifierListSyntax*& specList);
+    bool parseSpecifierQualifierList(DeclarationSyntax*& decl, SpecifierListSyntax*& specList);
     template <class SpecT> void parseTrivialSpecifier_AtFirst(
             SpecifierSyntax*& spec,
             SyntaxKind specK);

--- a/C/parser/Parser_Common.cpp
+++ b/C/parser/Parser_Common.cpp
@@ -44,7 +44,7 @@ bool Parser::parseTypeName(TypeNameSyntax*& typeName)
 
     DeclarationSyntax* decl = nullptr;
     SpecifierListSyntax* specList = nullptr;
-    if (!parseSpecifierQualifierList(decl, specList, false))
+    if (!parseSpecifierQualifierList(decl, specList))
         return false;
 
     typeName = makeNode<TypeNameSyntax>();

--- a/C/parser/Parser_Declarations.cpp
+++ b/C/parser/Parser_Declarations.cpp
@@ -824,8 +824,6 @@ bool Parser::parseExtKR_ParameterDeclaration(ExtKR_ParameterDeclarationSyntax*& 
     paramDecl = makeNode<ExtKR_ParameterDeclarationSyntax>();
     paramDecl->specs_ = specList;
 
-   // if (!paramDecl->specs_) return false;
-
     DeclaratorListSyntax** decltorList_cur = &paramDecl->decltors_;
     while (true) {
         DeclaratorSyntax* decltor = nullptr;
@@ -866,7 +864,7 @@ bool Parser::parseExtKR_ParameterDeclaration(ExtKR_ParameterDeclarationSyntax*& 
  */
 bool Parser::parseDeclarationSpecifiers(DeclarationSyntax*& decl,
                                         SpecifierListSyntax*& specList,
-                                        bool takeIdentifierAsDecltor)
+                                        bool allowIdentAsDecltor)
 {
     DEBUG_THIS_RULE();
 
@@ -1021,7 +1019,7 @@ bool Parser::parseDeclarationSpecifiers(DeclarationSyntax*& decl,
                 if (seenType)
                     return true;
 
-                if (takeIdentifierAsDecltor
+                if (allowIdentAsDecltor
                         && (determineIdentifierRole(seenType) == IdentifierRole::AsDeclarator))
                     return true;
 
@@ -1080,7 +1078,7 @@ bool Parser::parseDeclarationSpecifiers(DeclarationSyntax*& decl,
  */
 bool Parser::parseSpecifierQualifierList(DeclarationSyntax*& decl,
                                          SpecifierListSyntax*& specList,
-                                         bool takeIdentifierAsDecltor)
+                                         bool allowIdentAsDecltor)
 {
     DEBUG_THIS_RULE();
 
@@ -1184,7 +1182,7 @@ bool Parser::parseSpecifierQualifierList(DeclarationSyntax*& decl,
                 if (seenType)
                     return true;
 
-                if (takeIdentifierAsDecltor
+                if (allowIdentAsDecltor
                         && (determineIdentifierRole(seenType) == IdentifierRole::AsDeclarator))
                     return true;
 

--- a/C/parser/Parser_Declarations.cpp
+++ b/C/parser/Parser_Declarations.cpp
@@ -516,11 +516,8 @@ Parser::IdentifierRole Parser::determineIdentifierRole(bool seenType) const
                 continue;
 
             case SemicolonToken:
-                if (parenCnt < 0) {
-                    std::cout << "\nreturn as typedef name\n";
+                if (parenCnt < 0)
                     return IdentifierRole::AsTypedefName;
-                }
-                std::cout << "\nreturn as declarator\n";
                 return IdentifierRole::AsDeclarator;
 
             default:

--- a/C/parser/Parser_Declarations.cpp
+++ b/C/parser/Parser_Declarations.cpp
@@ -178,15 +178,14 @@ bool Parser::parseExtGNU_AsmStatementDeclaration_AtFirst(DeclarationSyntax*& dec
 
 bool Parser::parseDeclaration(
         DeclarationSyntax*& decl,
-        bool (Parser::*parseSpecifiers)(DeclarationSyntax*&, SpecifierListSyntax*&, bool),
+        bool (Parser::*parseSpecifiers)(DeclarationSyntax*&, SpecifierListSyntax*&),
         bool (Parser::*parse_AtFollowOfSpecifiers)(DeclarationSyntax*&, const SpecifierListSyntax*),
         DeclarationScope declScope)
 {
     SpecifierListSyntax* specList = nullptr;
     if (!((this)->*(parseSpecifiers))(
                 decl,
-                specList,
-                declScope != DeclarationScope::Block))
+                specList))
         return false;
 
     if (peek().kind() == SemicolonToken) {
@@ -769,7 +768,7 @@ bool Parser::parseParameterDeclaration(ParameterDeclarationSyntax*& paramDecl)
 
     DeclarationSyntax* decl = nullptr;
     SpecifierListSyntax* specList = nullptr;
-    if (!parseDeclarationSpecifiers(decl, specList, true))
+    if (!parseDeclarationSpecifiers(decl, specList))
         return false;
 
     if (!specList) {
@@ -843,7 +842,7 @@ bool Parser::parseExtKR_ParameterDeclaration(ExtKR_ParameterDeclarationSyntax*& 
 
     DeclarationSyntax* decl = nullptr;
     SpecifierListSyntax* specList = nullptr;
-    if (!parseDeclarationSpecifiers(decl, specList, false))
+    if (!parseDeclarationSpecifiers(decl, specList))
         return false;
 
     paramDecl = makeNode<ExtKR_ParameterDeclarationSyntax>();
@@ -888,8 +887,7 @@ bool Parser::parseExtKR_ParameterDeclaration(ExtKR_ParameterDeclarationSyntax*& 
  * \remark 6.7.1, 6.7.2, 6.7.3, 6.7.4, and 6.7.5
  */
 bool Parser::parseDeclarationSpecifiers(DeclarationSyntax*& decl,
-                                        SpecifierListSyntax*& specList,
-                                        bool allowIdentAsDecltor)
+                                        SpecifierListSyntax*& specList)
 {
     DEBUG_THIS_RULE();
 
@@ -1044,8 +1042,7 @@ bool Parser::parseDeclarationSpecifiers(DeclarationSyntax*& decl,
                 if (seenType)
                     return true;
 
-                if (/*allowIdentAsDecltor
-                        && */(determineIdentifierRole(seenType) == IdentifierRole::AsDeclarator))
+                if (determineIdentifierRole(seenType) == IdentifierRole::AsDeclarator)
                     return true;
 
                 seenType = true;
@@ -1102,8 +1099,7 @@ bool Parser::parseDeclarationSpecifiers(DeclarationSyntax*& decl,
  * \remark 6.7.2.1
  */
 bool Parser::parseSpecifierQualifierList(DeclarationSyntax*& decl,
-                                         SpecifierListSyntax*& specList,
-                                         bool allowIdentAsDecltor)
+                                         SpecifierListSyntax*& specList)
 {
     DEBUG_THIS_RULE();
 
@@ -1205,10 +1201,6 @@ bool Parser::parseSpecifierQualifierList(DeclarationSyntax*& decl,
             // declaration-specifiers -> type-specifier -> typedef-name
             case IdentifierToken: {
                 if (seenType)
-                    return true;
-
-                if (allowIdentAsDecltor
-                        && (determineIdentifierRole(seenType) == IdentifierRole::AsDeclarator))
                     return true;
 
                 seenType = true;

--- a/C/syntax/SyntaxNodes_Declarations.h
+++ b/C/syntax/SyntaxNodes_Declarations.h
@@ -957,14 +957,13 @@ class PSY_C_API FunctionDefinitionSyntax final : public DeclarationSyntax
 public:
     const SpecifierListSyntax* specifiers() const { return specs_; }
     const DeclaratorSyntax* declarator() const { return decltor_; }
-    const ExtKR_ParameterDeclarationListSyntax *extKR_params()
-        const { return extKR_params_; }
+    const ExtKR_ParameterDeclarationListSyntax* extKR_params() const { return extKR_params_; }
     const StatementSyntax* body() const { return body_; }
 
 private:
     SpecifierListSyntax* specs_ = nullptr;
     DeclaratorSyntax* decltor_ = nullptr;
-    ExtKR_ParameterDeclarationListSyntax *extKR_params_ = nullptr;
+    ExtKR_ParameterDeclarationListSyntax* extKR_params_ = nullptr;
     StatementSyntax* body_ = nullptr;
     AST_CHILD_LST4(specs_, decltor_, extKR_params_, body_);
 

--- a/C/tests/BinderTest_0000_0999.cpp
+++ b/C/tests/BinderTest_0000_0999.cpp
@@ -209,8 +209,20 @@ void BinderTest::case0024()
     bind("x __attribute__ ( ( ) ) int ;");
 }
 
-void BinderTest::case0025() {}
-void BinderTest::case0026() {}
+void BinderTest::case0025()
+{
+    CROSS_REFERENCE_TEST(ParserTest::case0297);
+
+    bind("void x ( int y ) int y ; { }");
+}
+
+void BinderTest::case0026()
+{
+    CROSS_REFERENCE_TEST(ParserTest::case0298);
+
+    bind("int x ( int y ) z y ; { }");
+}
+
 void BinderTest::case0027() {}
 void BinderTest::case0028() {}
 void BinderTest::case0029() {}

--- a/C/tests/ParserTest_0000_0999.cpp
+++ b/C/tests/ParserTest_0000_0999.cpp
@@ -814,14 +814,14 @@ void ParserTest::case0102()
 {
     parse("void ( * x ) ( ) { }",
           Expectation().diagnostic(Expectation::ErrorOrWarn::Error,
-                                      Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
+                                   Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
 }
 
 void ParserTest::case0103()
 {
     parse("void ( ( * x ) ) ( ) { }",
           Expectation().diagnostic(Expectation::ErrorOrWarn::Error,
-                                      Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
+                                   Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
 }
 
 void ParserTest::case0104()
@@ -2106,8 +2106,6 @@ void ParserTest::case0283()
 
 void ParserTest::case0284()
 {
-    // TODO: Should be error.
-
     parse("int x ( y , z ) int y , z ; { return y + z ; }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
@@ -2200,7 +2198,6 @@ void ParserTest::case0287()
 
 void ParserTest::case0288()
 {
-    // TODO: Should be error.
     parse("int x ( y , z ) int * y , z ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
@@ -2224,6 +2221,30 @@ void ParserTest::case0288()
 
 void ParserTest::case0289()
 {
+    parse("int x ( y , z ) int * y , * z ; { }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              PointerDeclarator,
+                              IdentifierDeclarator,
+                              PointerDeclarator,
+                              IdentifierDeclarator,
+                              CompoundStatement }));
+}
+
+void ParserTest::case0290()
+{
     parse("void x ( y ) int y ( float [ 1 ] ) ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
@@ -2245,10 +2266,6 @@ void ParserTest::case0289()
                               SubscriptSuffix,
                               IntegerConstantExpression,
                               CompoundStatement }));
-}
-
-void ParserTest::case0290()
-{
 }
 
 void ParserTest::case0291()
@@ -2325,71 +2342,18 @@ void ParserTest::case0296()
 
 void ParserTest::case0297()
 {
-    parse("int x ( t y ) int y ; { return y ; }",
-          Expectation().diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ));
+    // semantic
+    parse("void x ( t y ) int y ; { }");
 }
 
 void ParserTest::case0298()
 {
-    parse("int x ( int y ) int y ; { return y ; }",
-          Expectation().diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ));
+    // semantic
+    parse("int x ( int y ) int y ; { }");
 }
 
 void ParserTest::case0299()
 {
-    parse("int x ( int y , ... ) int z ; { return y ; }",
-          Expectation().diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ));
 }
 
 void ParserTest::case0300()
@@ -2505,7 +2469,7 @@ void ParserTest::case0311()
 {
     parse("int ( * const [ ] ) ( unsigned int , ... ) ;",
           Expectation().diagnostic(Expectation::ErrorOrWarn::Error,
-                                      Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofDirectDeclarator));
+                                   Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofDirectDeclarator));
 }
 
 void ParserTest::case0312()

--- a/C/tests/ParserTest_0000_0999.cpp
+++ b/C/tests/ParserTest_0000_0999.cpp
@@ -2256,78 +2256,70 @@ void ParserTest::case0292()
 
 void ParserTest::case0293()
 {
-    parse("int x ( y , z ) int y , int z { return y + z ; }",
-          Expectation().diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ));
+    parse("void x ( y , z ) int y , int z { }",
+          Expectation()
+              .diagnostic(Expectation::ErrorOrWarn::Error,
+                          Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
 }
 
 void ParserTest::case0294()
 {
-    parse("int x ( y ) y { return y ; }",
-          Expectation().diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ));
+    parse("int x ( y ) y { }",
+          Expectation()
+              .diagnostic(Expectation::ErrorOrWarn::Error,
+                          Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
 }
 
 void ParserTest::case0295()
 {
-    parse("int x ( y ) int { return y ; }",
-          Expectation().diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ));
+    parse("int x ( y ) int { }",
+          Expectation()
+              .diagnostic(Expectation::ErrorOrWarn::Error,
+                          Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
 }
 
 void ParserTest::case0296()
 {
-    parse("int x ( y ) int y { return y ; }",
-          Expectation().diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Warn,
-              Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier
-          ).diagnostic(
-              Expectation::ErrorOrWarn::Error,
-              Parser::DiagnosticsReporter::
-              ID_of_ExpectedFIRSTofDirectDeclarator
-          ));
+    parse("int x ( y ) int y { }",
+          Expectation()
+              .diagnostic(Expectation::ErrorOrWarn::Error,
+                          Parser::DiagnosticsReporter::ID_of_ExpectedFOLLOWofDeclarator));
 }
 
 void ParserTest::case0297()
 {
-    // semantic
-    parse("void x ( t y ) int y ; { }");
+    parse("void x ( int y ) int y ; { }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              CompoundStatement }));
 }
 
 void ParserTest::case0298()
 {
-    // semantic
-    parse("int x ( int y ) int y ; { }");
+    parse("int x ( int y ) z y ; { }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              ExtKR_ParameterDeclaration,
+                              TypedefName,
+                              IdentifierDeclarator,
+                              CompoundStatement }));
 }
 
 void ParserTest::case0299()

--- a/C/tests/ParserTest_0000_0999.cpp
+++ b/C/tests/ParserTest_0000_0999.cpp
@@ -2288,6 +2288,8 @@ void ParserTest::case0296()
 
 void ParserTest::case0297()
 {
+    CROSS_REFERENCE_TEST(BinderTest::case0025); // Semantic error.
+
     parse("void x ( int y ) int y ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
@@ -2306,6 +2308,8 @@ void ParserTest::case0297()
 
 void ParserTest::case0298()
 {
+    CROSS_REFERENCE_TEST(BinderTest::case0026);  // Semantic error.
+
     parse("int x ( int y ) z y ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,

--- a/C/tests/ParserTest_0000_0999.cpp
+++ b/C/tests/ParserTest_0000_0999.cpp
@@ -1580,14 +1580,14 @@ void ParserTest::case0216()
 {
     parse("x ( int y ) ;",
           Expectation().diagnostic(Expectation::ErrorOrWarn::Warn,
-                                      Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier));
+                                   Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier));
 }
 
 void ParserTest::case0217()
 {
     parse("x ( y z ) ;",
           Expectation().diagnostic(Expectation::ErrorOrWarn::Warn,
-                                      Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier));
+                                   Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier));
 }
 
 void ParserTest::case0218()
@@ -1602,9 +1602,9 @@ void ParserTest::case0219()
 
 void ParserTest::case0220()
 {
-    parse("void x ( ( int z ));",
-          Expectation().diagnostic(Expectation::ErrorOrWarn::Warn,
-                                      Parser::DiagnosticsReporter::ID_of_ExpectedTypeSpecifier));
+    parse("void x ( ( int z ) ) ;",
+          Expectation().diagnostic(Expectation::ErrorOrWarn::Error,
+                                   Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofParameterDeclaration));
 }
 
 void ParserTest::case0221()
@@ -1848,8 +1848,7 @@ void ParserTest::case0245()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               CompoundStatement }));
 }
 
@@ -2033,8 +2032,7 @@ void ParserTest::case0280()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               IdentifierDeclarator,
@@ -2051,8 +2049,7 @@ void ParserTest::case0281()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               TypedefName,
                               IdentifierDeclarator,
@@ -2069,11 +2066,9 @@ void ParserTest::case0282()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               IdentifierDeclarator,
@@ -2090,11 +2085,9 @@ void ParserTest::case0283()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               IdentifierDeclarator,
@@ -2106,7 +2099,7 @@ void ParserTest::case0283()
 
 void ParserTest::case0284()
 {
-    parse("int x ( y , z ) int y , z ; { return y + z ; }",
+    parse("void x ( y , z ) int y , z ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2114,20 +2107,14 @@ void ParserTest::case0284()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               IdentifierDeclarator,
                               IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              AddExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              CompoundStatement }));
 }
 
 void ParserTest::case0285()
@@ -2140,11 +2127,9 @@ void ParserTest::case0285()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               IdentifierDeclarator,
@@ -2169,8 +2154,7 @@ void ParserTest::case0286()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               StructTypeSpecifier,
                               IdentifierDeclarator,
@@ -2187,8 +2171,7 @@ void ParserTest::case0287()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               PointerDeclarator,
@@ -2206,11 +2189,9 @@ void ParserTest::case0288()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               PointerDeclarator,
@@ -2229,11 +2210,9 @@ void ParserTest::case0289()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               PointerDeclarator,
@@ -2253,8 +2232,7 @@ void ParserTest::case0290()
                               IdentifierDeclarator,
                               ParameterSuffix,
                               ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
+                              IdentifierDeclarator,
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               FunctionDeclarator,

--- a/C/tests/ParserTest_0000_0999.cpp
+++ b/C/tests/ParserTest_0000_0999.cpp
@@ -1809,7 +1809,7 @@ void ParserTest::case0243()
 {
     parse("int [ ] x ( ) { }",
           Expectation().diagnostic(Expectation::ErrorOrWarn::Error,
-                                      Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofDirectDeclarator));
+                                   Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofDirectDeclarator));
 }
 
 void ParserTest::case0244()
@@ -1840,7 +1840,17 @@ void ParserTest::case0244()
 
 void ParserTest::case0245()
 {
-
+    parse("void x ( y ) { }",
+          Expectation().AST({ TranslationUnit,
+                              FunctionDefinition,
+                              BuiltinTypeSpecifier,
+                              FunctionDeclarator,
+                              IdentifierDeclarator,
+                              ParameterSuffix,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
+                              CompoundStatement }));
 }
 
 void ParserTest::case0246()
@@ -2015,7 +2025,7 @@ void ParserTest::case0279()
 
 void ParserTest::case0280()
 {
-    parse("int x ( y ) { return y ; }",
+    parse("void x ( y ) int y ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2025,14 +2035,15 @@ void ParserTest::case0280()
                               ParameterDeclaration,
                               TypedefName,
                               AbstractDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              IdentifierName }));
+                              ExtKR_ParameterDeclaration,
+                              BuiltinTypeSpecifier,
+                              IdentifierDeclarator,
+                              CompoundStatement }));
 }
 
 void ParserTest::case0281()
 {
-    parse("int x ( y ) int y ; { return y ; }",
+    parse("void x ( y ) z y ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2043,16 +2054,14 @@ void ParserTest::case0281()
                               TypedefName,
                               AbstractDeclarator,
                               ExtKR_ParameterDeclaration,
-                              BuiltinTypeSpecifier,
+                              TypedefName,
                               IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              IdentifierName }));
+                              CompoundStatement }));
 }
 
 void ParserTest::case0282()
 {
-    parse("int x ( y , z ) int y ; { return y + z ; }",
+    parse("void x ( y , z ) int y ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2068,16 +2077,12 @@ void ParserTest::case0282()
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              AddExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              CompoundStatement }));
 }
 
 void ParserTest::case0283()
 {
-    parse("int x ( y , z ) int y ; int z ; { return y + z ; }",
+    parse("void x ( y , z ) int y ; int z ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2096,15 +2101,13 @@ void ParserTest::case0283()
                               ExtKR_ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              AddExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              CompoundStatement }));
 }
 
 void ParserTest::case0284()
 {
+    // TODO: Should be error.
+
     parse("int x ( y , z ) int y , z ; { return y + z ; }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
@@ -2131,7 +2134,7 @@ void ParserTest::case0284()
 
 void ParserTest::case0285()
 {
-    parse("int x ( y , z ) int y ; int z ( int ) ; { return y + z ( y ) ; }",
+    parse("void x ( y , z ) int y ; int z ( int ) ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2155,18 +2158,12 @@ void ParserTest::case0285()
                               ParameterDeclaration,
                               BuiltinTypeSpecifier,
                               AbstractDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              AddExpression,
-                              IdentifierName,
-                              CallExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              CompoundStatement }));
 }
 
 void ParserTest::case0286()
 {
-    parse("int x ( y ) struct t y ; { return y . z ; }",
+    parse("void x ( y ) struct z y ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2179,16 +2176,12 @@ void ParserTest::case0286()
                               ExtKR_ParameterDeclaration,
                               StructTypeSpecifier,
                               IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              DirectMemberAccessExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              CompoundStatement }));
 }
 
 void ParserTest::case0287()
 {
-    parse("int x ( y ) t y ; { return y . z ; }",
+    parse("void x ( y ) int * y ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2199,18 +2192,16 @@ void ParserTest::case0287()
                               TypedefName,
                               AbstractDeclarator,
                               ExtKR_ParameterDeclaration,
-                              TypedefName,
+                              BuiltinTypeSpecifier,
+                              PointerDeclarator,
                               IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              DirectMemberAccessExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              CompoundStatement }));
 }
 
 void ParserTest::case0288()
 {
-    parse("int x ( y ) union t y ; { return y . z ; }",
+    // TODO: Should be error.
+    parse("int x ( y , z ) int * y , z ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
@@ -2220,104 +2211,26 @@ void ParserTest::case0288()
                               ParameterDeclaration,
                               TypedefName,
                               AbstractDeclarator,
+                              ParameterDeclaration,
+                              TypedefName,
+                              AbstractDeclarator,
                               ExtKR_ParameterDeclaration,
-                              UnionTypeSpecifier,
+                              BuiltinTypeSpecifier,
+                              PointerDeclarator,
                               IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              DirectMemberAccessExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              IdentifierDeclarator,
+                              CompoundStatement }));
 }
 
 void ParserTest::case0289()
 {
-    parse("int x ( y ) int * y ; { return * y; }",
+    parse("void x ( y ) int y ( float [ 1 ] ) ; { }",
           Expectation().AST({ TranslationUnit,
                               FunctionDefinition,
                               BuiltinTypeSpecifier,
                               FunctionDeclarator,
                               IdentifierDeclarator,
                               ParameterSuffix,
-                              ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
-                              ExtKR_ParameterDeclaration,
-                              BuiltinTypeSpecifier,
-                              PointerDeclarator,
-                              IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              PointerIndirectionExpression,
-                              IdentifierName }));
-}
-
-void ParserTest::case0290()
-{
-    parse("int x ( y , z ) int * y , z ; { return * y + z ; }",
-          Expectation().AST({ TranslationUnit,
-                              FunctionDefinition,
-                              BuiltinTypeSpecifier,
-                              FunctionDeclarator,
-                              IdentifierDeclarator,
-                              ParameterSuffix,
-                              ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
-                              ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
-                              ExtKR_ParameterDeclaration,
-                              BuiltinTypeSpecifier,
-                              PointerDeclarator,
-                              IdentifierDeclarator,
-                              IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              AddExpression,
-                              PointerIndirectionExpression,
-                              IdentifierName,
-                              IdentifierName }));
-
-}
-
-void ParserTest::case0291()
-{
-    parse("_Complex double x ( y ) _Complex double * y ; { return * y ; }",
-          Expectation().AST({ TranslationUnit,
-                              FunctionDefinition,
-                              BuiltinTypeSpecifier,
-                              BuiltinTypeSpecifier,
-                              FunctionDeclarator,
-                              IdentifierDeclarator,
-                              ParameterSuffix,
-                              ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
-                              ExtKR_ParameterDeclaration,
-                              BuiltinTypeSpecifier,
-                              BuiltinTypeSpecifier,
-                              PointerDeclarator,
-                              IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              PointerIndirectionExpression,
-                              IdentifierName }));
-
-}
-
-void ParserTest::case0292()
-{
-    parse("float x ( y , z ) int y ( float [ 2 ] ) ; float * z  ; { return y ( z ) ; }",
-          Expectation().AST({ TranslationUnit,
-                              FunctionDefinition,
-                              BuiltinTypeSpecifier,
-                              FunctionDeclarator,
-                              IdentifierDeclarator,
-                              ParameterSuffix,
-                              ParameterDeclaration,
-                              TypedefName,
-                              AbstractDeclarator,
                               ParameterDeclaration,
                               TypedefName,
                               AbstractDeclarator,
@@ -2331,15 +2244,19 @@ void ParserTest::case0292()
                               ArrayDeclarator,
                               SubscriptSuffix,
                               IntegerConstantExpression,
-                              ExtKR_ParameterDeclaration,
-                              BuiltinTypeSpecifier,
-                              PointerDeclarator,
-                              IdentifierDeclarator,
-                              CompoundStatement,
-                              ReturnStatement,
-                              CallExpression,
-                              IdentifierName,
-                              IdentifierName }));
+                              CompoundStatement }));
+}
+
+void ParserTest::case0290()
+{
+}
+
+void ParserTest::case0291()
+{
+}
+
+void ParserTest::case0292()
+{
 }
 
 void ParserTest::case0293()

--- a/C/tests/Test.cpp
+++ b/C/tests/Test.cpp
@@ -39,7 +39,7 @@
 #include <sstream>
 
 #define DEBUG_DIAGNOSTICS
-//#define DUMP_AST
+#define DUMP_AST
 
 using namespace psy;
 using namespace C;

--- a/C/tests/Test.cpp
+++ b/C/tests/Test.cpp
@@ -38,8 +38,8 @@
 #include <string>
 #include <sstream>
 
-#define DEBUG_DIAGNOSTICS
-#define DUMP_AST
+//#define DEBUG_DIAGNOSTICS
+//#define DUMP_AST
 
 using namespace psy;
 using namespace C;


### PR DESCRIPTION
- PR with K&R parameters: f38ac13d3d8046e8827a8e84afaea0ec6f51e129
- FYI @luigidcsoares : it was a bit more complicated (that I originally thought) to fix the regular parameters of a K&R function from `TypedefName` to `IdentifierDeclarator`; I had to add a mechanism to delay diagnostics and adjust the LA for identifiers as declarators/typedefs.