### PR TITLE
improve lex of integer/floating (maybe imaginary) constants — and fix a bug

### DIFF
--- a/C/parser/Lexer.cpp
+++ b/C/parser/Lexer.cpp
@@ -1036,14 +1036,6 @@ void Lexer::lexFloatingConstantAndMaybeImaginary_AtExponent(SyntaxToken* tk, uns
     lexFloatingOrImaginaryFloatingSuffix(tk, yytext_ - yytext);
 }
 
-void Lexer::lexFloatingConstant_AtSuffix(SyntaxToken* tk, unsigned int accLeng)
-{
-    const char* yytext = yytext_ - accLeng;
-    lexFloatingSuffix();
-    tk->rawSyntaxK_ = FloatingConstantToken;
-    tk->floating_ = tree_->floatingConstant(yytext, yytext_ - yytext);
-}
-
 void Lexer::lexFloatingOrImaginaryFloatingSuffix(SyntaxToken* tk, unsigned int accLeng)
 {
     const char* yytext = yytext_ - accLeng;

--- a/C/parser/Lexer.cpp
+++ b/C/parser/Lexer.cpp
@@ -409,7 +409,7 @@ LexEntry:
                 }
             }
             else if (std::isdigit(yychar_)) {
-                lexFloatingConstantAndMaybeImaginary_AtFollowOfPeriod(tk, 1);
+                lexFloatingOrImaginaryFloating_AtFollowOfPeriod(tk, 1);
             }
             else {
                 tk->rawSyntaxK_ = DotToken;
@@ -898,12 +898,12 @@ void Lexer::lexIntegerOrFloatingConstant(SyntaxToken* tk)
     while (yychar_) {
         if (yychar_ == '.') {
             yyinput();
-            lexFloatingConstantAndMaybeImaginary_AtFollowOfPeriod(tk, yytext_ - yytext);
+            lexFloatingOrImaginaryFloating_AtFollowOfPeriod(tk, yytext_ - yytext);
             return;
         }
 
         if (yychar_ == 'e' || yychar_ == 'E') {
-            lexFloatingConstantAndMaybeImaginary_AtExponent(tk, yytext_ - yytext);
+            lexFloatingOrImaginaryFloating_AtExponent(tk, yytext_ - yytext);
             return;
         }
 
@@ -1022,14 +1022,14 @@ void Lexer::lexImaginaryIntegerSuffix_AtFirst(SyntaxToken* tk)
     tk->rawSyntaxK_ = ImaginaryIntegerConstantToken;
 }
 
-void Lexer::lexFloatingConstantAndMaybeImaginary_AtFollowOfPeriod(SyntaxToken* tk, unsigned int accLeng)
+void Lexer::lexFloatingOrImaginaryFloating_AtFollowOfPeriod(SyntaxToken* tk, unsigned int accLeng)
 {
     const char* yytext = yytext_ - accLeng;
     lexDigitSequence();
-    lexFloatingConstantAndMaybeImaginary_AtExponent(tk, yytext_ - yytext);
+    lexFloatingOrImaginaryFloating_AtExponent(tk, yytext_ - yytext);
 }
 
-void Lexer::lexFloatingConstantAndMaybeImaginary_AtExponent(SyntaxToken* tk, unsigned int accLeng)
+void Lexer::lexFloatingOrImaginaryFloating_AtExponent(SyntaxToken* tk, unsigned int accLeng)
 {
     const char* yytext = yytext_ - accLeng;
     lexExponentPart();

--- a/C/parser/Lexer.cpp
+++ b/C/parser/Lexer.cpp
@@ -930,7 +930,6 @@ void Lexer::lexIntegerOrFloating_AtFollowOfSuffix(SyntaxToken* tk,
     makeLexeme();
 }
 
-
 void Lexer::lexIntegerOrImaginaryIntegerSuffix(SyntaxToken* tk, unsigned int accLeng)
 {
     const char* yytext = yytext_ - accLeng;

--- a/C/parser/Lexer.h
+++ b/C/parser/Lexer.h
@@ -74,13 +74,12 @@ private:
     void lexImaginaryIntegerSuffix(SyntaxToken* tk);
     void lexImaginaryIntegerSuffix_AtFirst(SyntaxToken* tk);
 
+    void lexFloatingOrImaginaryFloating_AtFollowOfPeriod(SyntaxToken* tk, unsigned int accLeng);
+    void lexFloatingOrImaginaryFloating_AtExponent(SyntaxToken* tk, unsigned int accLeng);
     void lexFloatingOrImaginaryFloatingSuffix(SyntaxToken* tk, unsigned int accLeng);
     void lexFloatingSuffix();
     void lexImaginaryFloatingSuffix(SyntaxToken* tk);
     void lexImaginaryFloatingSuffix_AtFirst(SyntaxToken* tk);
-
-    void lexFloatingConstantAndMaybeImaginary_AtFollowOfPeriod(SyntaxToken* tk, unsigned int accLeng);
-    void lexFloatingConstantAndMaybeImaginary_AtExponent(SyntaxToken* tk, unsigned int accLeng);
 
     void lexDigitSequence();
     void lexHexadecimalDigitSequence();

--- a/C/parser/Lexer.h
+++ b/C/parser/Lexer.h
@@ -28,6 +28,7 @@
 #include "syntax/SyntaxToken.h"
 
 #include <cstdint>
+#include <functional>
 #include <string>
 
 namespace psy {

--- a/C/parser/Lexer.h
+++ b/C/parser/Lexer.h
@@ -81,7 +81,6 @@ private:
 
     void lexFloatingConstantAndMaybeImaginary_AtFollowOfPeriod(SyntaxToken* tk, unsigned int accLeng);
     void lexFloatingConstantAndMaybeImaginary_AtExponent(SyntaxToken* tk, unsigned int accLeng);
-    void lexFloatingConstant_AtSuffix(SyntaxToken* tk, unsigned int accLeng);
 
     void lexDigitSequence();
     void lexHexadecimalDigitSequence();

--- a/C/parser/Lexer.h
+++ b/C/parser/Lexer.h
@@ -64,26 +64,30 @@ private:
     void lexIdentifier(SyntaxToken* tk, int advanced = 0);
 
     /* 6.4.4 Constants */
+    void lexCharacterConstant(SyntaxToken* tk, unsigned char prefix = 0);
+
     void lexIntegerOrFloatingConstant(SyntaxToken* tk);
     void lexIntegerOrFloating_AtFollowOfSuffix(SyntaxToken* tk, std::function<void ()>);
 
-    void lexIntegerSuffixAndMaybeImaginary(SyntaxToken* tk, unsigned int accLeng);
-
-    void lexFloatingConstantAndMaybeImaginary_AtSuffix(SyntaxToken* tk, unsigned int accLeng);
-    void lexImaginaryFloatingConstant_AtFirstSuffix(SyntaxToken* tk, unsigned int accLeng);
-    void lexImaginaryFloatingConstant_AtFollowSuffix_TOCHANGE(SyntaxToken* tk, unsigned int accLeng);
+    void lexIntegerOrImaginaryIntegerSuffix(SyntaxToken* tk, unsigned int accLeng);
+    void lexIntegerSuffix(int suffixCnt = 2);
     void lexImaginaryIntegerSuffix(SyntaxToken* tk);
+    void lexImaginaryIntegerSuffix_AtFirst(SyntaxToken* tk);
+
+    void lexFloatingOrImaginaryFloatingSuffix(SyntaxToken* tk, unsigned int accLeng);
+    void lexFloatingSuffix();
+    void lexImaginaryFloatingSuffix(SyntaxToken* tk);
+    void lexImaginaryFloatingSuffix_AtFirst(SyntaxToken* tk);
+
     void lexFloatingConstantAndMaybeImaginary_AtFollowOfPeriod(SyntaxToken* tk, unsigned int accLeng);
     void lexFloatingConstantAndMaybeImaginary_AtExponent(SyntaxToken* tk, unsigned int accLeng);
     void lexFloatingConstant_AtSuffix(SyntaxToken* tk, unsigned int accLeng);
-    void lexIntegerSuffix(int suffixCnt = 2);
+
     void lexDigitSequence();
     void lexHexadecimalDigitSequence();
     void lexExponentPart();
     void lexBinaryExponentPart();
     void lexSign();
-    void lexFloatingSuffix();
-    void lexCharacterConstant(SyntaxToken* tk, unsigned char prefix = 0);
 
     /* 6.4.5 String literals */
     void lexStringLiteral(SyntaxToken* tk, unsigned char prefix = 0);

--- a/C/parser/Lexer.h
+++ b/C/parser/Lexer.h
@@ -65,10 +65,13 @@ private:
 
     /* 6.4.4 Constants */
     void lexIntegerOrFloatingConstant(SyntaxToken* tk);
+    void lexIntegerOrFloating_AtFollowOfSuffix(SyntaxToken* tk, std::function<void ()>);
+
+    void lexIntegerSuffixAndMaybeImaginary(SyntaxToken* tk, unsigned int accLeng);
+
     void lexFloatingConstantAndMaybeImaginary_AtSuffix(SyntaxToken* tk, unsigned int accLeng);
     void lexImaginaryFloatingConstant_AtFirstSuffix(SyntaxToken* tk, unsigned int accLeng);
-    void lexImaginaryFloatingConstant_AtFollowSuffix(SyntaxToken* tk, unsigned int accLeng);
-    void lexIntegerSuffixAndMaybeImaginary(SyntaxToken* tk);
+    void lexImaginaryFloatingConstant_AtFollowSuffix_TOCHANGE(SyntaxToken* tk, unsigned int accLeng);
     void lexImaginaryIntegerSuffix(SyntaxToken* tk);
     void lexFloatingConstantAndMaybeImaginary_AtFollowOfPeriod(SyntaxToken* tk, unsigned int accLeng);
     void lexFloatingConstantAndMaybeImaginary_AtExponent(SyntaxToken* tk, unsigned int accLeng);

--- a/C/tests/ParserTest_1000_1999.cpp
+++ b/C/tests/ParserTest_1000_1999.cpp
@@ -634,8 +634,22 @@ void ParserTest::case1094()
                         Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofExpression));
 }
 
-void ParserTest::case1095() {}
-void ParserTest::case1096() {}
+void ParserTest::case1095()
+{
+    parseExpression(".1fllf",
+                    Expectation().diagnostic(
+                        Expectation::ErrorOrWarn::Error,
+                        Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofExpression));
+}
+
+void ParserTest::case1096()
+{
+    parseExpression("0.1fllf",
+                    Expectation().diagnostic(
+                        Expectation::ErrorOrWarn::Error,
+                        Parser::DiagnosticsReporter::ID_of_ExpectedFIRSTofExpression));
+}
+
 void ParserTest::case1097() {}
 void ParserTest::case1098() {}
 void ParserTest::case1099() {}


### PR DESCRIPTION
- fix lex of invalid floating suffixes and test cases (1095 and 1096)
- rework a bit of integer/imaginary integer and floating/imaginary floating to:
    - eliminate the "double check" for `i` or `j` in the case where a prior `if` already determined the FIRST of sentence
    - have a common function for post/invalid suffixes handling, passing a lambda: `lexIntegerOrFloating_AtFollowOfSuffix`
    - make the lex of integer and floating (maybe imaginary) equivalent, using the same method sequences
```
    void lexXXXOrImaginaryXXXSuffix(SyntaxToken* tk, unsigned int accLeng);
    void lexXXXSuffix();
    void lexImaginaryXXXSuffix(SyntaxToken* tk);
    void lexImaginaryXXXSuffix_AtFirst(SyntaxToken* tk);
``` 
 
FYI @ludanpr  ☝🏽 
