### PR TITLE
Account for both forms of if statement in disambiguator

### DIFF
--- a/C/reparser/Disambiguator.cpp
+++ b/C/reparser/Disambiguator.cpp
@@ -382,7 +382,8 @@ SyntaxVisitor::Action Disambiguator::visitIfStatement(const IfStatementSyntax* n
 {
     visitMaybeAmbiguousExpression(node->cond_);
     visitMaybeAmbiguousStatement(node->stmt_);
-    visitMaybeAmbiguousStatement(node->elseStmt_);
+    if (node->elseStmt_)
+        visitMaybeAmbiguousStatement(node->elseStmt_);
 
     return Action::Skip;
 }

--- a/C/syntax/SyntaxLexeme.h
+++ b/C/syntax/SyntaxLexeme.h
@@ -27,6 +27,7 @@
 
 #include "../common/text/TextElement.h"
 
+#include <cstdint>
 #include <string>
 
 namespace psy {

--- a/cnippet/CompilerFrontend_C.cpp
+++ b/cnippet/CompilerFrontend_C.cpp
@@ -29,6 +29,8 @@
 #include "plugin-api/SourceInspector.h"
 #include "syntax/SyntaxNamePrinter.h"
 
+#include <iterator>
+
 using namespace cnip;
 using namespace psy;
 using namespace C;


### PR DESCRIPTION
I think a more bare bones case of the issue reported in #125 is

```c
int main(void)
{
    if (0) {
        T(T);
    }
}
```

After marking the ambiguity, when reparsing the _if statement_, `elseStmt_` is `nullptr` and is passed on to `visitMaybeAmbiguousStatement`, causing a null pointer dereference.

https://github.com/ltcmelo/psychec/blob/eabdcce6a57d9531acd7d7ebd1d43cbe918a73d0/C/reparser/Disambiguator.cpp#L385

https://github.com/ltcmelo/psychec/blob/eabdcce6a57d9531acd7d7ebd1d43cbe918a73d0/C/reparser/Disambiguator.cpp#L91

Simplistically, the PR proposes to account for both forms of if statements